### PR TITLE
Fix: 지방 파싱 관련 잘못된 로직 수정 (#12)

### DIFF
--- a/utils/nutrition_parser.py
+++ b/utils/nutrition_parser.py
@@ -8,10 +8,7 @@ def parse_nutrients_from_text(text):
     matches = re.findall(nutrient_pattern, text)
     print(matches)
     nutrient_dict = {}
-    nutrient_dict['탄수화물'] = -1
-    nutrient_dict['당류'] = -1
-    nutrient_dict['단백질'] = -1
-    nutrient_dict['지방'] = -1
+    fats = [] # 지방, 포화지방, 트랜스지방을 담아 가장 큰 값을 지방으로 판단
 
     for match in matches:
         if match[0] == '물': # 물로 끝나면 탄수화물이라고 판단
@@ -20,17 +17,17 @@ def parse_nutrients_from_text(text):
             nutrient_dict['당류'] = float(match[1])
         elif match[0] == '질': # 질로 끝나면 단백질이라고 판단
             if match[1].startswith('0') and len(match[1]) > 1: # 0으로 시작하는데 소수점을 잃은 경우(02g 등)에 대한 예외처리
-                nutrient_dict['단백질'] += float(match[1]) / 10
+                nutrient_dict['단백질'] = float(match[1]) / 10
                 continue
             nutrient_dict['단백질'] = float(match[1])
         elif match[0] == '방': # 방으로 끝나면 지방, 포화지방, 트랜스지방 이라고 판단 (합계)
             if match[1].startswith('0') and len(match[1]) > 1: # 0으로 시작하는데 소수점을 잃은 경우(02g 등)에 대한 예외처리
-                nutrient_dict['지방'] += float(match[1]) / 10
+                fats.append(float(match[1]) / 10)
                 continue
-            nutrient_dict['지방'] += float(match[1])
-    if nutrient_dict['지방'] != -1:
-        nutrient_dict['지방'] += 1 # 지방은 합계로 나오기 때문에 최초의 -1을 감안하여 1을 더해줌
+            fats.append(float(match[1]))
 
+    if len(fats) != 0:
+        nutrient_dict['지방'] = max(fats) # "방"으로 끝나는 것들의 숫자를 파싱한 값 중 가장 큰 값을 지방으로 판단 (포함의 관계이므로)
     kcal_matches = re.findall(kcal_pattern, text) # 칼로리는 kcal로 끝나는 숫자
     if not kcal_matches:
         nutrient_dict['칼로리'] = -1


### PR DESCRIPTION
* 현재 지방+포화지방+트랜스지방을 지방으로 계산하는 것이 잘못된 로직임을 인지
* "방"으로 끝나는 영양소는 위와 같이 1~3개 존재할 것임
* 이 3개 중 가장 큰 값이 지방이라고 간주하도록 수정 (포화지방과 트랜스지방은 지방에 포함되는 관계이기에 지방보다 클 수 없음)